### PR TITLE
feat: implement `service` module

### DIFF
--- a/src/lib/data/mod.rs
+++ b/src/lib/data/mod.rs
@@ -65,3 +65,9 @@ impl FromStr for DbId {
         Ok(DbId(Uuid::parse_str(s)?))
     }
 }
+
+impl From<DbId> for String {
+    fn from(id: DbId) -> Self {
+        id.0.to_string()
+    }
+}

--- a/src/lib/data/model.rs
+++ b/src/lib/data/model.rs
@@ -98,4 +98,14 @@ pub struct UpdateClip {
     pub(in crate::data) password: Option<String>,
 }
 
-// impl From<crate::service::ask::UpdateClip> for UpdateClip {}
+impl From<crate::service::ask::UpdateClip> for UpdateClip {
+    fn from(req: crate::service::ask::UpdateClip) -> Self {
+        Self {
+            shortcode: req.shortcode.into_inner(),
+            content: req.content.into_inner(),
+            title: req.title.into_inner(),
+            expires: req.expires.into_inner().map(|time|time.timestamp()),
+            password: req.password.into_inner()
+        }
+    }
+}

--- a/src/lib/data/model.rs
+++ b/src/lib/data/model.rs
@@ -40,6 +40,15 @@ pub struct GetClip {
     pub(in crate::data) shortcode: String,
 }
 
+// convert GetClip from ask into GetClip model in order to send it to data layer
+impl From<crate::service::ask::GetClip> for GetClip {
+    fn from(req: crate::service::ask::GetClip) -> Self {
+        Self {
+            shortcode: req.shortcode.into_inner()
+        }
+    }
+}
+
 impl From<ShortCode> for GetClip {
     fn from(shortcode: ShortCode) -> Self {
         GetClip {

--- a/src/lib/data/model.rs
+++ b/src/lib/data/model.rs
@@ -70,10 +70,23 @@ pub struct NewClip {
     pub(in crate::data) shortcode: String,
     pub(in crate::data) content: String,
     pub(in crate::data) title: Option<String>,
-    pub(in crate::data) posted: i16,
-    pub(in crate::data) expires: Option<NaiveDateTime>,
+    pub(in crate::data) posted: i64,
+    pub(in crate::data) expires: Option<i64>,
     pub(in crate::data) password: Option<String>,
-    pub(in crate::data) hits: i64,
+}
+
+impl From<crate::service::ask::NewClip> for NewClip {
+    fn from(req: crate::service::ask::NewClip) -> Self {
+        Self {
+            clip_id: DbId::new().into(),
+            shortcode: ShortCode::new().into(),
+            content: req.content.into_inner(),
+            title: req.title.into_inner(),
+            posted: Utc::now().timestamp(),
+            expires: req.expires.into_inner().map(|time|time.timestamp().into()),
+            password: req.password.into_inner()
+        }
+    }
 }
 
 
@@ -84,3 +97,5 @@ pub struct UpdateClip {
     pub(in crate::data) expires: Option<i64>,
     pub(in crate::data) password: Option<String>,
 }
+
+// impl From<crate::service::ask::UpdateClip> for UpdateClip {}

--- a/src/lib/data/query.rs
+++ b/src/lib/data/query.rs
@@ -6,7 +6,7 @@ use crate::data::model::GetClip;
 
 type Result<T> = std::result::Result<T, DataError>;
 
-pub async fn get_clip<M: Into<model::GetClip>>(model: M, pool: &DbPool) -> Result<model::Clip> {
+pub async fn get_clip<M: Into<GetClip>>(model: M, pool: &DbPool) -> Result<model::Clip> {
     let model = model.into();
     let shortcode = model.shortcode.as_str();
     Ok(sqlx::query_as!(model::Clip, "SELECT * FROM clips WHERE shortcode = ?", shortcode).fetch_one(pool).await?)

--- a/src/lib/domain/clip/field/password.rs
+++ b/src/lib/domain/clip/field/password.rs
@@ -26,7 +26,7 @@ impl Password {
     }
 
     // need to expose this publicly to be able to check (constructor param is private)
-    pub fn has_password(self) -> bool {
+    pub fn has_password(&self) -> bool {
           self.0.is_some()
     }
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,4 +1,5 @@
 pub mod data;
+pub use data::DataError;
 
 pub mod domain;
 pub use domain::clip::field::ShortCode;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -4,8 +4,10 @@ pub use data::DataError;
 pub mod domain;
 pub use domain::clip::field::ShortCode;
 pub use domain::clip::ClipError;
+pub use domain::clip::Clip;
 pub use domain::Time;
 
 pub mod service;
+pub use service::ServiceError;
 
 pub mod web;

--- a/src/lib/service/action.rs
+++ b/src/lib/service/action.rs
@@ -25,4 +25,6 @@ pub async fn new_clip(req: ask::NewClip, pool: &DbPool) -> Result<Clip, ServiceE
     Ok(query::new_clip(req, pool).await?.try_into()?)
 }
 
-// pub async fn update_clip(req: ask::NewClip, pool: &DbPool) -> Result<Clip, ServiceError> {}
+pub async fn update_clip(req: ask::UpdateClip, pool: &DbPool) -> Result<Clip, ServiceError> {
+    Ok(query::update_clip(req, pool).await?.try_into()?)
+}

--- a/src/lib/service/action.rs
+++ b/src/lib/service/action.rs
@@ -1,0 +1,22 @@
+use crate::data::{query, DbPool, Tx};
+use crate::service::ask;
+use crate::{Clip, ServiceError, ShortCode};
+
+use std::convert::TryInto;
+
+pub async fn get_clip(req: ask::GetClip, pool: &DbPool) -> Result<Clip, ServiceError> {
+    let user_password = req.password.clone();
+    // From impl convert ask GetClip into data GetClip
+    // TryFrom impl convert model Clip result into domain Clip
+    let clip: Clip = query::get_clip(req, pool).await?.try_into()?;
+
+    if clip.password.has_password() {
+        if clip.password == user_password {
+            Ok(clip)
+        } else {
+            Err(ServiceError::PermissionError("Invalid password".to_owned()))
+        }
+    } else {
+        Ok(clip)
+    }
+}

--- a/src/lib/service/action.rs
+++ b/src/lib/service/action.rs
@@ -6,8 +6,8 @@ use std::convert::TryInto;
 
 pub async fn get_clip(req: ask::GetClip, pool: &DbPool) -> Result<Clip, ServiceError> {
     let user_password = req.password.clone();
-    // From impl convert ask GetClip into data GetClip
-    // TryFrom impl convert model Clip result into domain Clip
+    // From impl converts ask GetClip into data GetClip
+    // TryFrom impl converts model Clip result into domain Clip
     let clip: Clip = query::get_clip(req, pool).await?.try_into()?;
 
     if clip.password.has_password() {
@@ -20,3 +20,9 @@ pub async fn get_clip(req: ask::GetClip, pool: &DbPool) -> Result<Clip, ServiceE
         Ok(clip)
     }
 }
+
+pub async fn new_clip(req: ask::NewClip, pool: &DbPool) -> Result<Clip, ServiceError> {
+    Ok(query::new_clip(req, pool).await?.try_into()?)
+}
+
+// pub async fn update_clip(req: ask::NewClip, pool: &DbPool) -> Result<Clip, ServiceError> {}

--- a/src/lib/service/ask.rs
+++ b/src/lib/service/ask.rs
@@ -1,4 +1,4 @@
-use crate::domain::clip::field;
+use crate::domain::clip::field::*;
 use crate::ShortCode;
 use derive_more::Constructor;
 use serde::{Deserialize, Serialize};
@@ -7,14 +7,14 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GetClip {
     pub shortcode: ShortCode,
-    pub password: field::Password,
+    pub password: Password,
 }
 
 impl GetClip {
     fn from_raw(shortcode:&str) -> Self {
         Self {
             shortcode: ShortCode::from(shortcode),
-            password: field::Password::default()
+            password: Password::default()
         }
     }
 }
@@ -23,7 +23,7 @@ impl From<ShortCode> for GetClip {
     fn from(shortcode: ShortCode) -> Self {
         Self {
             shortcode,
-            password: field::Password::default()
+            password: Password::default()
         }
     }
 }
@@ -36,10 +36,17 @@ impl From<&str> for GetClip {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct NewClip {
-    pub content: field::Content,
-    pub title: field::Title,
-    pub expires: field::Expires,
-    pub password: field::Password,
+    pub content: Content,
+    pub title: Title,
+    pub expires: Expires,
+    pub password: Password,
 }
 
-// pub struct UpdateClip {}
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UpdateClip {
+    pub shortcode: ShortCode,
+    pub content: Content,
+    pub title: Title,
+    pub expires: Expires,
+    pub password: Password
+}

--- a/src/lib/service/ask.rs
+++ b/src/lib/service/ask.rs
@@ -33,3 +33,13 @@ impl From<&str> for GetClip {
         Self::from_raw(raw)
     }
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct NewClip {
+    pub content: field::Content,
+    pub title: field::Title,
+    pub expires: field::Expires,
+    pub password: field::Password,
+}
+
+// pub struct UpdateClip {}

--- a/src/lib/service/ask.rs
+++ b/src/lib/service/ask.rs
@@ -1,0 +1,35 @@
+use crate::domain::clip::field;
+use crate::ShortCode;
+use derive_more::Constructor;
+use serde::{Deserialize, Serialize};
+
+// all fields can be public as we already implemented validation in domain
+#[derive(Debug, Deserialize, Serialize)]
+pub struct GetClip {
+    pub shortcode: ShortCode,
+    pub password: field::Password,
+}
+
+impl GetClip {
+    fn from_raw(shortcode:&str) -> Self {
+        Self {
+            shortcode: ShortCode::from(shortcode),
+            password: field::Password::default()
+        }
+    }
+}
+
+impl From<ShortCode> for GetClip {
+    fn from(shortcode: ShortCode) -> Self {
+        Self {
+            shortcode,
+            password: field::Password::default()
+        }
+    }
+}
+
+impl From<&str> for GetClip {
+    fn from(raw: &str) -> Self {
+        Self::from_raw(raw)
+    }
+}

--- a/src/lib/service/mod.rs
+++ b/src/lib/service/mod.rs
@@ -1,0 +1,35 @@
+use sqlx::Error;
+use crate::{ClipError, DataError};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ServiceError {
+    #[error("clip error: {0}")]
+    Clip(#[from] ClipError),
+    #[error("database error: {0}")]
+    Data(DataError),
+    #[error("not found")]
+    NotFound,
+    #[error("permissions not met {0}")]
+    PermissionError(String),
+}
+
+impl From<DataError> for ServiceError {
+    fn from(err: DataError) -> Self {
+        match err {
+            DataError::Database(d) => match d {
+                Error::RowNotFound => Self::NotFound,
+                other => Self::Data(DataError::Database(other))
+            }
+        }
+    }
+}
+
+// for convenience
+impl From<Error> for ServiceError {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::RowNotFound => Self::NotFound,
+            other=> Self::Data(DataError::Database(other))
+        }
+    }
+}

--- a/src/lib/service/mod.rs
+++ b/src/lib/service/mod.rs
@@ -1,3 +1,6 @@
+pub mod ask;
+pub mod action;
+
 use sqlx::Error;
 use crate::{ClipError, DataError};
 


### PR DESCRIPTION
- implement `ask` types used in `service::action`(s)
- implement `service::action`(s) that will be called by `web` service and sent to `data::query` module
- implement type conversion function between types from `service::ask` and types from `data::model`